### PR TITLE
Bumping es to 7.17.4; setting grafana to 8.5.6

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,1 +1,1 @@
-FROM elasticsearch:7.17.3
+FROM elasticsearch:7.17.4

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana
+FROM grafana/grafana:8.5.6
 
 ADD --chown=grafana:root Grafana-DMARC_Reports.json /var/lib/grafana/dashboards/
 RUN chmod 644 /etc/grafana/provisioning


### PR DESCRIPTION
Due to compatibility issues of grafana 9 with elastic search 7.17, grafana has been set to 8.5.6 version