### PR TITLE
Add weekly DMARC report generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 archive_files.log
 fetch_attachments_config.json
 fetch_attachments.log
+weekly_report.log
+/reports/
 /.idea/
 .venv/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In order to have the geoip data populated and visible on the map in the dashboar
 
 ## Usage
 
-### 1. Configure the email fetcher
+### Setup (once)
 
 `fetch_attachments.py` pulls DMARC report attachments from an IMAP mailbox
 (e.g. Gmail) into `files/`. Copy the example config and fill it in:
@@ -47,7 +47,11 @@ cp fetch_attachments_example_config.json fetch_attachments_config.json
         "label": "DMARC",
         "to": "dmarc-reports@example.com"
     },
-    "local": { "directory": "files", "overwrite": true }
+    "local": { "directory": "files", "overwrite": true },
+    "report": {
+        "directory": "reports",
+        "es_url": "http://localhost:9200"
+    }
 }
 ```
 
@@ -55,18 +59,27 @@ Notes:
 * The config is gitignored — your credentials never get committed.
 * For Gmail, enable 2FA and use an [App Password](https://myaccount.google.com/apppasswords), not your normal password.
 * `label` is the IMAP mailbox/label name and is **case-sensitive** (Gmail labels appear verbatim, e.g. `DMARC`).
+* The `report` section configures the weekly report (step 3 below) and is
+  optional — these values are the defaults.
 
-### 2. Fetch reports
+On the first run, backfill everything already in the mailbox:
 
 ```
-python3 fetch_attachments.py            # unread messages only (normal weekly run)
-python3 fetch_attachments.py --seen     # all messages, including already-read (first run / backfill)
-python3 fetch_attachments.py --since 01-Jan-2026   # date-bounded
+python3 fetch_attachments.py --seen     # all messages, including already-read
 ```
 
-Fetching a message marks it read, so subsequent default runs only pick up new reports.
+### Weekly flow
 
-### 3. Parse and visualize
+#### 1. Fetch new reports
+
+```
+python3 fetch_attachments.py            # unread messages only
+python3 fetch_attachments.py --since 01-Jan-2026   # or date-bounded
+```
+
+Fetching a message marks it read, so the next default run only picks up new reports.
+
+#### 2. Parse and visualize
 
 ```
 docker compose up -d                    # parsedmarc parses files/ into Elasticsearch, then exits
@@ -80,19 +93,32 @@ Check that parsing succeeded:
 ```
 docker compose ps                       # parsedmarc should show "Exited (0)"
 tail -n 20 output_files/parsedmarc.log
-# Elasticsearch is not published to the host; query it from inside the container:
-docker exec dmarc-visualizer-elasticsearch-1 \
-  curl -s 'localhost:9200/_cat/indices/dmarc*?v&h=index,docs.count'
+curl -s 'localhost:9200/_cat/indices/dmarc*?v&h=index,docs.count'
 ```
 
-Stop everything with `docker compose down` — parsed data persists in the
-`elastic_data/` volume.
+(Elasticsearch is published host-only on `127.0.0.1:9200`.)
 
-### 4. Housekeeping (optional)
+#### 3. Generate the weekly report
+
+`weekly_report.py` queries Elasticsearch (it does not re-read `files/`) and
+summarizes the last 7 days vs. the 7 before: volume, DMARC pass rate,
+SPF/DKIM alignment failures, top failing sources, and any sending sources
+never seen before. Each report is saved to `reports/` (gitignored) and
+printed to stdout.
+
+```
+python3 weekly_report.py                # writes reports/dmarc_<start>_to_<end>.txt
+python3 weekly_report.py --days 30 --end 2026-07-01   # custom window
+```
+
+#### 4. Housekeeping (optional)
 
 ```
 python3 archive_files.py                # move already-parsed files older than 8 days to .old/
 ```
+
+When done, stop everything with `docker compose down` — parsed data persists
+in the `elastic_data/` volume.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
 
   elasticsearch:
     build: ./elasticsearch/
+    ports:
+      - 127.0.0.1:9200:9200   # host-only, for weekly_report.py
     volumes:
       - ./elastic_data:/usr/share/elasticsearch/data
     environment:

--- a/fetch_attachments_example_config.json
+++ b/fetch_attachments_example_config.json
@@ -11,5 +11,9 @@
     "local": {
         "directory": "directory to save attachments",
         "overwrite": true
+    },
+    "report": {
+        "directory": "reports",
+        "es_url": "http://localhost:9200"
     }
 }

--- a/test_weekly_report.py
+++ b/test_weekly_report.py
@@ -1,0 +1,239 @@
+import datetime
+import json
+
+import weekly_report
+
+
+def make_agg_response():
+    """A realistic Elasticsearch aggregation response for one report window."""
+    return {
+        'aggregations': {
+            'total': {'value': 1234.0},
+            'passed': {'count': {'value': 1200.0}},
+            'spf_fail': {'count': {'value': 40.0}},
+            'dkim_fail': {'count': {'value': 22.0}},
+            'spf_rescued': {'count': {'value': 6.0}},
+            'dkim_rescued': {'count': {'value': 28.0}},
+            'dispositions': {'buckets': [
+                {'key': 'none', 'count': {'value': 1220.0}},
+                {'key': 'quarantine', 'count': {'value': 14.0}},
+            ]},
+            'domains': {'buckets': [
+                {'key': 'deyta.ai', 'count': {'value': 1200.0}, 'passed': {'count': {'value': 1180.0}}},
+                {'key': 'staging.deyta.ai', 'count': {'value': 34.0}, 'passed': {'count': {'value': 20.0}}},
+            ]},
+            'countries': {'buckets': [
+                {'key': 'US', 'count': {'value': 1200.0}},
+                {'key': 'RS', 'count': {'value': 34.0}},
+                {'key': '', 'count': {'value': 1.0}},
+            ]},
+            'reporters': {'buckets': [
+                {'key': 'google.com', 'count': {'value': 900.0}},
+                {'key': 'Enterprise Outlook', 'count': {'value': 334.0}},
+            ]},
+            'sources': {'buckets': [
+                {'key': 'google.com', 'count': {'value': 1000.0}},
+                {'key': 'sendgrid.net', 'count': {'value': 234.0}},
+                {'key': '', 'count': {'value': 5.0}},
+            ]},
+            'failing': {
+                'count': {'value': 34.0},
+                'by_source': {'buckets': [
+                    {'key': '203.0.113.9', 'count': {'value': 30.0},
+                     'rdns': {'buckets': [{'key': 'mail.evil.example'}]}},
+                    {'key': '198.51.100.7', 'count': {'value': 4.0}, 'rdns': {'buckets': []}},
+                ]},
+                'spf_results': {'buckets': [
+                    {'key': 'softfail', 'count': {'value': 30.0}},
+                    {'key': 'none', 'count': {'value': 4.0}},
+                ]},
+                'dkim_results': {'buckets': [{'key': 'fail', 'count': {'value': 34.0}}]},
+                'dkim_selectors': {'buckets': [{'key': 'google'}, {'key': 's1'}]},
+            },
+        }
+    }
+
+
+def empty_stats():
+    return weekly_report.extract_stats({})
+
+
+class TestWindowBounds:
+    def test_default_week(self):
+        end = datetime.date(2026, 7, 21)
+        prev_start, cur_start, cur_end = weekly_report.window_bounds(end, 7)
+        assert cur_end == end
+        assert cur_start == datetime.date(2026, 7, 14)
+        assert prev_start == datetime.date(2026, 7, 7)
+
+    def test_windows_are_contiguous_and_equal_length(self):
+        prev_start, cur_start, cur_end = weekly_report.window_bounds(datetime.date(2026, 3, 1), 30)
+        assert (cur_end - cur_start) == (cur_start - prev_start)
+
+
+class TestExtractStats:
+    def test_counts(self):
+        stats = weekly_report.extract_stats(make_agg_response())
+        assert stats['total'] == 1234
+        assert stats['passed'] == 1200
+        assert stats['spf_fail'] == 40
+        assert stats['dkim_fail'] == 22
+        assert stats['spf_rescued'] == 6
+        assert stats['dkim_rescued'] == 28
+        assert stats['dmarc_fail'] == 34
+        assert stats['dispositions'] == {'none': 1220, 'quarantine': 14}
+        assert stats['reporters'][0] == ('google.com', 900)
+
+    def test_domain_stats(self):
+        stats = weekly_report.extract_stats(make_agg_response())
+        assert stats['domains'] == ['deyta.ai', 'staging.deyta.ai']
+        assert stats['domain_stats']['staging.deyta.ai'] == {'total': 34, 'passed': 20}
+
+    def test_countries_empty_key_dropped(self):
+        stats = weekly_report.extract_stats(make_agg_response())
+        assert stats['countries'] == {'US': 1200, 'RS': 34}
+
+    def test_failing_detail(self):
+        stats = weekly_report.extract_stats(make_agg_response())
+        assert stats['failing_spf_results'] == {'softfail': 30, 'none': 4}
+        assert stats['failing_dkim_results'] == {'fail': 34}
+        assert stats['failing_dkim_selectors'] == ['google', 's1']
+
+    def test_empty_source_domain_dropped(self):
+        stats = weekly_report.extract_stats(make_agg_response())
+        assert '' not in stats['sources']
+        assert stats['sources'] == {'google.com': 1000, 'sendgrid.net': 234}
+
+    def test_failing_sources_with_and_without_rdns(self):
+        stats = weekly_report.extract_stats(make_agg_response())
+        assert stats['failing_sources'][0] == {'ip': '203.0.113.9', 'rdns': 'mail.evil.example', 'count': 30}
+        assert stats['failing_sources'][1]['rdns'] == ''
+
+    def test_empty_response(self):
+        stats = empty_stats()
+        assert stats['total'] == 0
+        assert stats['failing_sources'] == []
+        assert stats['sources'] == {}
+        assert stats['domain_stats'] == {}
+        assert stats['countries'] == {}
+
+
+class TestPassRate:
+    def test_normal(self):
+        assert weekly_report.pass_rate({'total': 200, 'passed': 150}) == 75.0
+
+    def test_zero_total_is_none_not_crash(self):
+        assert weekly_report.pass_rate({'total': 0, 'passed': 0}) is None
+        assert weekly_report._fmt_rate(None) == 'n/a'
+
+
+class TestRenderText:
+    def render(self, cur=None, prev=None, new_sources=frozenset(), new_countries=frozenset()):
+        return weekly_report.render_text(
+            cur if cur is not None else empty_stats(),
+            prev if prev is not None else empty_stats(),
+            set(new_sources), set(new_countries),
+            datetime.date(2026, 7, 14), datetime.date(2026, 7, 21))
+
+    def test_contains_key_numbers(self):
+        cur = weekly_report.extract_stats(make_agg_response())
+        text = self.render(cur, new_sources={'sendgrid.net'})
+        assert 'deyta.ai' in text
+        assert '1,234' in text
+        assert '97.2%' in text          # 1200/1234
+        assert 'prev n/a' in text
+        assert 'sendgrid.net (234 messages)' in text
+        assert '203.0.113.9' in text
+        assert 'mail.evil.example' in text
+        assert '(no reverse DNS)' in text
+
+    def test_per_domain_section(self):
+        cur = weekly_report.extract_stats(make_agg_response())
+        prev = weekly_report.extract_stats(make_agg_response())
+        text = self.render(cur, prev)
+        assert '58.8% pass' in text     # staging 20/34
+        assert '(prev 34 msgs, 58.8%)' in text
+        text_no_prev = self.render(cur)
+        assert '(not seen in previous window)' in text_no_prev
+
+    def test_failure_detail_section(self):
+        cur = weekly_report.extract_stats(make_agg_response())
+        text = self.render(cur)
+        assert 'SPF not aligned, DKIM saved it' in text
+        assert 'Both failed (DMARC fail):             34' in text
+        assert 'softfail: 30' in text
+        assert 'DKIM selectors on failing mail: google, s1' in text
+
+    def test_failure_detail_omits_raw_results_when_all_pass(self):
+        text = self.render()
+        assert 'SPF results on failing mail' not in text
+
+    def test_countries_with_new_marker(self):
+        cur = weekly_report.extract_stats(make_agg_response())
+        text = self.render(cur, new_countries={'RS'})
+        assert 'US: 1,200' in text
+        assert 'RS*: 34' in text
+        assert '(* first time seen)' in text
+        text_no_new = self.render(cur)
+        assert '*' not in text_no_new.split('Source countries:')[1].split('\n')[0]
+
+    def test_empty_week(self):
+        text = self.render()
+        assert '(no reports received)' in text
+        assert 'n/a' in text
+        assert 'Source countries' not in text
+        # per-domain, new sources, failing sources and reporters all render as "(none)"
+        assert text.count('(none)') == 4
+
+
+class TestSaveReport:
+    def test_creates_directory_and_file(self, tmp_path):
+        report_dir = tmp_path / 'reports'
+        path = weekly_report.save_report('report body', str(report_dir),
+                                         datetime.date(2026, 7, 14), datetime.date(2026, 7, 21))
+        assert path == str(report_dir / 'dmarc_2026-07-14_to_2026-07-21.txt')
+        assert (report_dir / 'dmarc_2026-07-14_to_2026-07-21.txt').read_text() == 'report body\n'
+
+
+class TestQueries:
+    def test_stats_query_window(self):
+        query = weekly_report.build_stats_query(datetime.date(2026, 7, 14), datetime.date(2026, 7, 21))
+        assert query['query']['range']['date_range'] == {'gte': '2026-07-14', 'lt': '2026-07-21'}
+        assert query['size'] == 0
+        assert json.dumps(query)  # serializable
+
+    def test_previously_seen_short_circuits_on_empty(self):
+        # must not hit Elasticsearch at all when there are no values
+        assert weekly_report.find_previously_seen(
+            'http://nope:1', 'source_base_domain.keyword', set(), datetime.date(2026, 1, 1)) == set()
+
+    def test_previously_seen_queries_before_window(self, monkeypatch):
+        captured = {}
+
+        def fake_search(es_url, body):
+            captured['body'] = body
+            return {'aggregations': {'seen': {'buckets': [{'key': 'google.com'}]}}}
+
+        monkeypatch.setattr(weekly_report, 'es_search', fake_search)
+        seen = weekly_report.find_previously_seen(
+            'http://es:9200', 'source_base_domain.keyword', {'google.com', 'sendgrid.net'},
+            datetime.date(2026, 7, 14))
+        assert seen == {'google.com'}
+        filters = captured['body']['query']['bool']['filter']
+        assert {'range': {'date_range': {'lt': '2026-07-14'}}} in filters
+        assert {'terms': {'source_base_domain.keyword': ['google.com', 'sendgrid.net']}} in filters
+
+
+class TestLoadConfig:
+    def test_report_section_overrides(self, tmp_path):
+        config_file = tmp_path / 'config.json'
+        config_file.write_text(json.dumps({
+            'auth': {'username': 'me@example.com', 'password': 'secret'},
+            'report': {'directory': 'weekly', 'es_url': 'http://other:9200'},
+        }))
+        cfg = weekly_report.load_config(str(config_file))
+        assert cfg == {'es_url': 'http://other:9200', 'report_dir': 'weekly'}
+
+    def test_missing_file_falls_back_to_defaults(self):
+        cfg = weekly_report.load_config('does-not-exist.json')
+        assert cfg == {'es_url': 'http://localhost:9200', 'report_dir': 'reports'}

--- a/weekly_report.py
+++ b/weekly_report.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Generate a weekly DMARC summary from the Elasticsearch data populated by
+parsedmarc.
+
+The report is always saved as a file under the report directory (default:
+reports/, gitignored) and also printed to stdout. Reads
+fetch_attachments_config.json only for an optional [report] section
+(Elasticsearch URL, report directory) — no credentials are needed.
+"""
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+
+log = logging.getLogger(__name__)
+
+INDEX_PATTERN = 'dmarc_aggregate*'
+TOP_N = 10
+MAX_SOURCES = 500
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Generate a weekly DMARC summary from Elasticsearch')
+    parser.add_argument('--days', dest='days', type=int, default=7,
+                        help='Length of the report window in days (default: 7)')
+    parser.add_argument('--end', dest='end', default=None,
+                        help='End of the report window as YYYY-MM-DD (default: today, UTC)')
+    parser.add_argument('--config', dest='config', default='fetch_attachments_config.json',
+                        help='Path to the config file')
+    parser.add_argument('--debug', dest='debug', default=False, action='store_true', help='Debug mode.')
+    return parser.parse_args()
+
+
+def load_config(config_file='fetch_attachments_config.json'):
+    try:
+        with open(config_file, 'r') as f:
+            config = json.loads(f.read())
+    except OSError:
+        config = {}  # the config is optional here; fall back to defaults
+
+    report = config.get('report', {})
+    return {
+        'es_url': report.get('es_url', 'http://localhost:9200'),
+        'report_dir': report.get('directory', 'reports'),
+    }
+
+
+def configure_logging(verbose, debug=False):
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+
+    file_handler = logging.FileHandler(filename='weekly_report.log')
+    handlers = [file_handler]
+
+    if verbose:
+        import sys
+        # stderr, so that report output on stdout stays clean for piping
+        handlers.append(logging.StreamHandler(sys.stderr))
+
+    logging.basicConfig(
+        level=logging.INFO if not debug else logging.DEBUG,
+        format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S',
+        handlers=handlers
+    )
+
+
+def window_bounds(end, days):
+    """Return (prev_start, cur_start, cur_end) dates for the current window
+    [cur_start, cur_end) and the previous window [prev_start, cur_start)."""
+    cur_start = end - datetime.timedelta(days=days)
+    prev_start = end - datetime.timedelta(days=2 * days)
+    return prev_start, cur_start, end
+
+
+def es_search(es_url, body):
+    url = f'{es_url}/{INDEX_PATTERN}/_search'
+    request = urllib.request.Request(
+        url, data=json.dumps(body).encode(), headers={'Content-Type': 'application/json'}, method='POST')
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read())
+
+
+def build_stats_query(start, end):
+    count = {'count': {'sum': {'field': 'message_count'}}}
+    aligned = lambda field, value: {'term': {field: value}}  # noqa: E731
+    return {
+        'size': 0,
+        'query': {'range': {'date_range': {'gte': start.isoformat(), 'lt': end.isoformat()}}},
+        'aggs': {
+            'total': {'sum': {'field': 'message_count'}},
+            'passed': {'filter': {'term': {'passed_dmarc': True}}, 'aggs': count},
+            'spf_fail': {'filter': {'term': {'spf_aligned': False}}, 'aggs': count},
+            'dkim_fail': {'filter': {'term': {'dkim_aligned': False}}, 'aggs': count},
+            'spf_rescued': {'filter': {'bool': {'filter': [
+                aligned('spf_aligned', False), aligned('dkim_aligned', True)]}}, 'aggs': count},
+            'dkim_rescued': {'filter': {'bool': {'filter': [
+                aligned('dkim_aligned', False), aligned('spf_aligned', True)]}}, 'aggs': count},
+            'dispositions': {'terms': {'field': 'disposition.keyword', 'size': TOP_N}, 'aggs': count},
+            'domains': {'terms': {'field': 'header_from.keyword', 'size': TOP_N, 'order': {'count': 'desc'}},
+                        'aggs': {**count, 'passed': {'filter': {'term': {'passed_dmarc': True}}, 'aggs': count}}},
+            'countries': {'terms': {'field': 'source_country.keyword', 'size': TOP_N,
+                                    'order': {'count': 'desc'}}, 'aggs': count},
+            'reporters': {'terms': {'field': 'org_name.keyword', 'size': TOP_N,
+                                    'order': {'count': 'desc'}}, 'aggs': count},
+            'sources': {'terms': {'field': 'source_base_domain.keyword', 'size': MAX_SOURCES}, 'aggs': count},
+            'failing': {
+                'filter': {'term': {'passed_dmarc': False}},
+                'aggs': {
+                    **count,
+                    'by_source': {
+                        'terms': {'field': 'source_ip_address.keyword', 'size': TOP_N,
+                                  'order': {'count': 'desc'}},
+                        'aggs': {**count, 'rdns': {'terms': {'field': 'source_reverse_dns.keyword', 'size': 1}}},
+                    },
+                    'spf_results': {'terms': {'field': 'spf_results.result.keyword', 'size': TOP_N},
+                                    'aggs': count},
+                    'dkim_results': {'terms': {'field': 'dkim_results.result.keyword', 'size': TOP_N},
+                                     'aggs': count},
+                    'dkim_selectors': {'terms': {'field': 'dkim_results.selector.keyword', 'size': TOP_N}},
+                },
+            },
+        },
+    }
+
+
+def _bucket_count(bucket):
+    return int(bucket.get('count', {}).get('value') or 0)
+
+
+def extract_stats(response):
+    aggs = response.get('aggregations', {})
+
+    def buckets(name, path=None):
+        agg = aggs.get(name, {})
+        for step in path or []:
+            agg = agg.get(step, {})
+        return agg.get('buckets', [])
+
+    failing_sources = []
+    for bucket in buckets('failing', ['by_source']):
+        rdns_buckets = bucket.get('rdns', {}).get('buckets', [])
+        failing_sources.append({
+            'ip': bucket['key'],
+            'rdns': rdns_buckets[0]['key'] if rdns_buckets else '',
+            'count': _bucket_count(bucket),
+        })
+
+    return {
+        'total': int(aggs.get('total', {}).get('value') or 0),
+        'passed': _bucket_count(aggs.get('passed', {})),
+        'spf_fail': _bucket_count(aggs.get('spf_fail', {})),
+        'dkim_fail': _bucket_count(aggs.get('dkim_fail', {})),
+        'spf_rescued': _bucket_count(aggs.get('spf_rescued', {})),
+        'dkim_rescued': _bucket_count(aggs.get('dkim_rescued', {})),
+        'dmarc_fail': _bucket_count(aggs.get('failing', {})),
+        'dispositions': {b['key']: _bucket_count(b) for b in buckets('dispositions')},
+        'domains': [b['key'] for b in buckets('domains')],
+        'domain_stats': {b['key']: {'total': _bucket_count(b), 'passed': _bucket_count(b.get('passed', {}))}
+                         for b in buckets('domains')},
+        'countries': {b['key']: _bucket_count(b) for b in buckets('countries') if b['key']},
+        'reporters': [(b['key'], _bucket_count(b)) for b in buckets('reporters')],
+        'sources': {b['key']: _bucket_count(b) for b in buckets('sources') if b['key']},
+        'failing_sources': failing_sources,
+        'failing_spf_results': {b['key']: _bucket_count(b) for b in buckets('failing', ['spf_results'])},
+        'failing_dkim_results': {b['key']: _bucket_count(b) for b in buckets('failing', ['dkim_results'])},
+        'failing_dkim_selectors': [b['key'] for b in buckets('failing', ['dkim_selectors'])],
+    }
+
+
+def find_previously_seen(es_url, field, values, before):
+    """Return the subset of values for `field` that also appears before the current window."""
+    if not values:
+        return set()
+    body = {
+        'size': 0,
+        'query': {'bool': {'filter': [
+            {'terms': {field: sorted(values)}},
+            {'range': {'date_range': {'lt': before.isoformat()}}},
+        ]}},
+        'aggs': {'seen': {'terms': {'field': field, 'size': MAX_SOURCES}}},
+    }
+    response = es_search(es_url, body)
+    return {b['key'] for b in response.get('aggregations', {}).get('seen', {}).get('buckets', [])}
+
+
+def pass_rate(stats):
+    if not stats['total']:
+        return None
+    return 100.0 * stats['passed'] / stats['total']
+
+
+def _fmt_rate(rate):
+    return 'n/a' if rate is None else f'{rate:.1f}%'
+
+
+def _fmt_counts(counts):
+    return ', '.join(f'{k}: {v:,}' for k, v in sorted(counts.items(), key=lambda i: -i[1]))
+
+
+def render_text(cur, prev, new_sources, new_countries, cur_start, cur_end):
+    lines = [
+        f'DMARC weekly report: {", ".join(cur["domains"]) or "(no reports received)"}',
+        f'Window: {cur_start} to {cur_end} (previous window in parentheses)',
+        '',
+        f'  Messages:         {cur["total"]:>7,}   (prev {prev["total"]:,})',
+        f'  DMARC pass rate:  {_fmt_rate(pass_rate(cur)):>7}   (prev {_fmt_rate(pass_rate(prev))})',
+        f'  SPF not aligned:  {cur["spf_fail"]:>7,}   (prev {prev["spf_fail"]:,})',
+        f'  DKIM not aligned: {cur["dkim_fail"]:>7,}   (prev {prev["dkim_fail"]:,})',
+        '',
+    ]
+
+    lines.append('Per domain:')
+    for domain in cur['domains']:
+        stats = cur['domain_stats'][domain]
+        rate = _fmt_rate(pass_rate(stats))
+        prev_stats = prev['domain_stats'].get(domain)
+        prev_note = (f'(prev {prev_stats["total"]:,} msgs, {_fmt_rate(pass_rate(prev_stats))})'
+                     if prev_stats else '(not seen in previous window)')
+        lines.append(f'  - {domain:<28} {stats["total"]:>7,} msgs   {rate:>6} pass   {prev_note}')
+    if not cur['domains']:
+        lines.append('  (none)')
+    lines.append('')
+
+    dispositions = _fmt_counts(cur['dispositions']) or 'none'
+    lines.append(f'Dispositions: {dispositions}')
+    lines.append('')
+
+    lines.append('Alignment failure detail:')
+    lines.append(f'  SPF not aligned, DKIM saved it:  {cur["spf_rescued"]:>7,}')
+    lines.append(f'  DKIM not aligned, SPF saved it:  {cur["dkim_rescued"]:>7,}')
+    lines.append(f'  Both failed (DMARC fail):        {cur["dmarc_fail"]:>7,}')
+    if cur['dmarc_fail']:
+        if cur['failing_spf_results']:
+            lines.append(f'  SPF results on failing mail:  {_fmt_counts(cur["failing_spf_results"])}')
+        if cur['failing_dkim_results']:
+            lines.append(f'  DKIM results on failing mail: {_fmt_counts(cur["failing_dkim_results"])}')
+        if cur['failing_dkim_selectors']:
+            lines.append(f'  DKIM selectors on failing mail: {", ".join(cur["failing_dkim_selectors"])}')
+    lines.append('')
+
+    if cur['countries']:
+        marked = {f'{c}*' if c in new_countries else c: n for c, n in cur['countries'].items()}
+        legend = '   (* first time seen)' if new_countries else ''
+        lines.append(f'Source countries: {_fmt_counts(marked)}{legend}')
+        lines.append('')
+
+    lines.append('New sending sources (never seen before this window):')
+    if new_sources:
+        for domain in sorted(new_sources):
+            lines.append(f'  - {domain} ({cur["sources"].get(domain, 0):,} messages)')
+    else:
+        lines.append('  (none)')
+    lines.append('')
+
+    lines.append('Top sources failing DMARC:')
+    if cur['failing_sources']:
+        for source in cur['failing_sources']:
+            rdns = source['rdns'] or '(no reverse DNS)'
+            lines.append(f'  - {source["ip"]:<40} {rdns:<40} {source["count"]:,}')
+    else:
+        lines.append('  (none)')
+    lines.append('')
+
+    reporters = ', '.join(f'{name}: {count:,}' for name, count in cur['reporters']) or '(none)'
+    lines.append(f'Reports received from: {reporters}')
+    return '\n'.join(lines)
+
+
+def report_path(report_dir, cur_start, cur_end):
+    return os.path.join(report_dir, f'dmarc_{cur_start}_to_{cur_end}.txt')
+
+
+def save_report(text, report_dir, cur_start, cur_end):
+    """Write the report into report_dir and return its path."""
+    os.makedirs(report_dir, exist_ok=True)
+    path = report_path(report_dir, cur_start, cur_end)
+    with open(path, 'w') as f:
+        f.write(text + '\n')
+    log.info(f'Report saved to {path}')
+    return path
+
+
+def main():
+    args = parse_args()
+    configure_logging(verbose=True, debug=args.debug)
+
+    cfg = load_config(args.config)
+
+    if args.end:
+        end = datetime.date.fromisoformat(args.end)
+    else:
+        end = datetime.datetime.now(datetime.timezone.utc).date()
+    prev_start, cur_start, cur_end = window_bounds(end, args.days)
+
+    try:
+        cur = extract_stats(es_search(cfg['es_url'], build_stats_query(cur_start, cur_end)))
+        prev = extract_stats(es_search(cfg['es_url'], build_stats_query(prev_start, cur_start)))
+        seen_sources = find_previously_seen(
+            cfg['es_url'], 'source_base_domain.keyword', set(cur['sources']), cur_start)
+        seen_countries = find_previously_seen(
+            cfg['es_url'], 'source_country.keyword', set(cur['countries']), cur_start)
+    except urllib.error.URLError as e:
+        log.error(f'Could not query Elasticsearch at {cfg["es_url"]}: {e}. '
+                  'Is the stack running? Try: docker compose up -d')
+        quit(-1)
+
+    new_sources = set(cur['sources']) - seen_sources
+    new_countries = set(cur['countries']) - seen_countries
+    text = render_text(cur, prev, new_sources, new_countries, cur_start, cur_end)
+
+    print(text)
+    save_report(text, cfg['report_dir'], cur_start, cur_end)
+    log.info('All done!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- New `weekly_report.py`: queries the `dmarc_aggregate-*` Elasticsearch indices (read-only, no re-parsing of `files/`) and writes a summary of the trailing 7 days vs. the 7 before to the gitignored `reports/` directory (also printed to stdout). `--days`/`--end` allow arbitrary windows, e.g. `--days 365` for a first-run baseline.
- Report contents: volume, DMARC pass rate, SPF/DKIM alignment failures (all with previous-window comparison), per-domain breakdown, alignment failure detail (rescued-by-DKIM/SPF vs. real failures, raw SPF/DKIM results and selectors on failing mail), source countries and sending sources never seen before, top failing source IPs with reverse DNS, and reporter orgs.
- Elasticsearch is now published host-only on `127.0.0.1:9200` so the script can reach it from the host.
- Optional `report` config section (`directory`, `es_url`) in `fetch_attachments_config.json`; no credentials needed.
- README Usage restructured into "Setup (once)" + numbered "Weekly flow" (fetch → parse → report → archive).

## Test plan
- [x] `python -m pytest` — 47 passed (16 new tests: window math, aggregation parsing, per-domain/failure-detail/country rendering, empty-week edge cases, file saving, config defaults)
- [x] Live runs against real data (7-day, 30-day, 365-day windows) — verified new-source/new-country detection and failure detail against the actual parsedmarc ES mapping